### PR TITLE
Remove wishlist endpoint and use Steam API

### DIFF
--- a/SteamWishlistTtBGraphQL/GraphQL/Query.cs
+++ b/SteamWishlistTtBGraphQL/GraphQL/Query.cs
@@ -6,6 +6,7 @@ namespace SteamWishlistTtBGraphQL.GraphQL
 {
     public class Query
     {
+        [UseFiltering]
         public async Task<List<Game>> GetGamesAsync(string userId, [Service] ISteamService steamService) 
             => (await steamService.GetSteamGamesAsync(userId))
                 .Select(x => Game.FromSteamGame(x)).ToList();

--- a/SteamWishlistTtBGraphQL/GraphQL/Query.cs
+++ b/SteamWishlistTtBGraphQL/GraphQL/Query.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
 using SteamWishlistTtBGraphQL.GraphQL.Schema;
+using SteamWishlistTtBGraphQL.Models;
+using SteamWishlistTtBGraphQL.Models.Responses;
 using SteamWishlistTtBGraphQL.Services;
 
 namespace SteamWishlistTtBGraphQL.GraphQL
@@ -7,8 +9,15 @@ namespace SteamWishlistTtBGraphQL.GraphQL
     public class Query
     {
         [UseFiltering]
-        public async Task<List<Game>> GetGamesAsync(string userId, [Service] ISteamService steamService) 
-            => (await steamService.GetSteamGamesAsync(userId))
-                .Select(x => Game.FromSteamGame(x)).ToList();
+        public async Task<IEnumerable<MyGame>> GetGamesAsync(string userId, [Service] IQueryService queryService)
+            => await queryService.GetGamesAsync(userId);
+
+        [UseFiltering]
+        public async Task<IGDBGameTimeToBeat> GetTimeToBeatAsync(string game, [Service] IQueryService queryService)
+            => await queryService.GetIGDBTimeToBeatAsync(game);
+
+        [UseFiltering]
+        public async Task<IEnumerable<IGDBGameTimeToBeat>> GetSteamGamesTimeToBeatAsync(string userId, [Service] IQueryService queryService)
+            => await queryService.GetSteamGamesTTBAsync(userId);
     }
 }

--- a/SteamWishlistTtBGraphQL/GraphQL/Schema/Game.cs
+++ b/SteamWishlistTtBGraphQL/GraphQL/Schema/Game.cs
@@ -5,18 +5,11 @@ namespace SteamWishlistTtBGraphQL.GraphQL.Schema
     public class Game
     {
         public string Title { get; set; }
-        public string ReleaseDate { get; set; }
-        public string ReleaseDateString { get; set; }
 
 
-        public static Game FromSteamGame(SteamGameModel steamGame)
+        public static Game FromSteamGame(SteamGameModel steamGame) => new Game
         {
-            return new Game
-            {
-                Title = steamGame.Name,
-                ReleaseDate = steamGame.ReleaseDate,
-                ReleaseDateString = steamGame.ReleaseDateString
-            };
-        }
+            Title = steamGame.Name
+        };
     }
 }

--- a/SteamWishlistTtBGraphQL/GraphQL/Schema/MyGame.cs
+++ b/SteamWishlistTtBGraphQL/GraphQL/Schema/MyGame.cs
@@ -2,12 +2,11 @@
 
 namespace SteamWishlistTtBGraphQL.GraphQL.Schema
 {
-    public class Game
+    public class MyGame
     {
         public string Title { get; set; }
 
-
-        public static Game FromSteamGame(SteamGameModel steamGame) => new Game
+        public static MyGame FromSteamGame(SteamGameModel steamGame) => new MyGame
         {
             Title = steamGame.Name
         };

--- a/SteamWishlistTtBGraphQL/Models/IGDBGameTimeToBeat.cs
+++ b/SteamWishlistTtBGraphQL/Models/IGDBGameTimeToBeat.cs
@@ -1,0 +1,54 @@
+﻿using IGDB.Models;
+using static HotChocolate.ErrorCodes;
+using System.Collections.Generic;
+using System.Drawing;
+using System;
+using Newtonsoft.Json;
+
+namespace SteamWishlistTtBGraphQL.Models
+{
+    public class IGDBGameTimeToBeat
+    {
+        [JsonProperty("checksum")]
+        public string Checksum { get; set; }
+
+        [JsonProperty("completely")]
+        public string Completely { get; set; }
+
+        [JsonProperty("count")]
+        public int Count { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonProperty("game_id")]
+        public int GameId { get; set; }
+
+        [JsonProperty("hastily")]
+        public int Hastily { get; set; }
+
+        [JsonProperty("normally")]
+        public int Normally { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTimeOffset UpdatedAt { get; set; }
+
+        public string GameName { get; set; }
+
+        private string _NormallyFormatted;
+        public string NormallyFormatted 
+        { 
+            get 
+            { 
+                if (_NormallyFormatted is null)
+                {
+                    TimeSpan time = TimeSpan.FromSeconds(Normally);
+                    _NormallyFormatted = $"{time.Hours} hours and {time.Minutes} minutes";
+                }
+
+                return _NormallyFormatted;
+            } 
+        }
+
+    }
+}

--- a/SteamWishlistTtBGraphQL/Models/IGDBSettings.cs
+++ b/SteamWishlistTtBGraphQL/Models/IGDBSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace SteamWishlistTtBGraphQL.Models
+{
+    public class IGDBSettings
+    {
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+    }
+}

--- a/SteamWishlistTtBGraphQL/Models/Responses/IGDB/IGDBTokenResponseModel.cs
+++ b/SteamWishlistTtBGraphQL/Models/Responses/IGDB/IGDBTokenResponseModel.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace SteamWishlistTtBGraphQL.Models.Responses
+{
+    public class IGDBTokenResponseModel
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; }
+    }
+}

--- a/SteamWishlistTtBGraphQL/Models/Responses/Steam/SteamOwnedGamesResponse.cs
+++ b/SteamWishlistTtBGraphQL/Models/Responses/Steam/SteamOwnedGamesResponse.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using SteamWishlistTtBGraphQL.Models;
 
-namespace SteamWishlistTtBGraphQL.Responses.Steam
+namespace SteamWishlistTtBGraphQL.Models.Responses
 {
     public class SteamOwnedGamesResponse
     {

--- a/SteamWishlistTtBGraphQL/Models/SteamGameModel.cs
+++ b/SteamWishlistTtBGraphQL/Models/SteamGameModel.cs
@@ -7,10 +7,8 @@ namespace SteamWishlistTtBGraphQL.Models
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonProperty("release_date")]
-        public string ReleaseDate { get; set; }
+        [JsonProperty("appId")]
+        public string AppId { get; set; }
 
-        [JsonProperty("release_string")]
-        public string ReleaseDateString { get; set; }
     }
 }

--- a/SteamWishlistTtBGraphQL/Models/SteamSettings.cs
+++ b/SteamWishlistTtBGraphQL/Models/SteamSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace SteamWishlistTtBGraphQL.Models
+{
+    public class SteamSettings
+    {
+        public string ApiKey { get; set; }
+    }
+}

--- a/SteamWishlistTtBGraphQL/Properties/launchSettings.json
+++ b/SteamWishlistTtBGraphQL/Properties/launchSettings.json
@@ -1,31 +1,23 @@
-﻿{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:28482",
-      "sslPort": 44393
-    }
-  },
+{
   "profiles": {
     "http": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5127",
+      "launchUrl": "http://localhost:5127/graphql",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5127"
     },
     "https": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7104;http://localhost:5127",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:7104;http://localhost:5127"
     },
     "IIS Express": {
       "commandName": "IISExpress",
@@ -33,6 +25,15 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:28482",
+      "sslPort": 44393
     }
   }
 }

--- a/SteamWishlistTtBGraphQL/Responses/Steam/SteamOwnedGamesResponse.cs
+++ b/SteamWishlistTtBGraphQL/Responses/Steam/SteamOwnedGamesResponse.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using SteamWishlistTtBGraphQL.Models;
+
+namespace SteamWishlistTtBGraphQL.Responses.Steam
+{
+    public class SteamOwnedGamesResponse
+    {
+        [JsonProperty("game_count")]
+        public int GameCount { get; set; }
+
+        [JsonProperty("games")]
+        public List<SteamGameModel> Games { get; set; }
+    }
+}

--- a/SteamWishlistTtBGraphQL/ServiceCollectionExtensions.cs
+++ b/SteamWishlistTtBGraphQL/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using SteamWishlistTtBGraphQL.GraphQL;
 using SteamWishlistTtBGraphQL.Services;
-using SteamWishlistTtBGraphQL.Services.SecretsService;
 
 namespace SteamWishlistTtBGraphQL
 {
@@ -20,6 +19,8 @@ namespace SteamWishlistTtBGraphQL
         {
             return services
                 .AddScoped<ISecretsService, SecretsService>()
+                .AddScoped<IIGDBService, IGDBService>()
+                .AddScoped<IQueryService, QueryService>()
                 .AddScoped<ISteamService, SteamService>();
         }
     }

--- a/SteamWishlistTtBGraphQL/ServiceCollectionExtensions.cs
+++ b/SteamWishlistTtBGraphQL/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using SteamWishlistTtBGraphQL.GraphQL;
 using SteamWishlistTtBGraphQL.Services;
+using SteamWishlistTtBGraphQL.Services.SecretsService;
 
 namespace SteamWishlistTtBGraphQL
 {
@@ -11,12 +12,14 @@ namespace SteamWishlistTtBGraphQL
                 .AddCors()
                 .AddServices()
                 .AddGraphQLServer()
+                .AddFiltering()
                 .AddQueryType<Query>();
         }
 
         public static IServiceCollection AddServices(this IServiceCollection services)
         {
             return services
+                .AddScoped<ISecretsService, SecretsService>()
                 .AddScoped<ISteamService, SteamService>();
         }
     }

--- a/SteamWishlistTtBGraphQL/Services/IGDBService/IGDBService.cs
+++ b/SteamWishlistTtBGraphQL/Services/IGDBService/IGDBService.cs
@@ -1,0 +1,89 @@
+﻿using IGDB;
+using IGDB.Models;
+using Newtonsoft.Json;
+using SteamWishlistTtBGraphQL.Models;
+using SteamWishlistTtBGraphQL.Models.Responses;
+using SteamWishlistTtBGraphQL.Services;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SteamWishlistTtBGraphQL.Services
+{
+    /// <summary>
+    /// This service is responsible for interacting with IGDB via a third party wrapper.
+    /// 500 limit is explicitly used in queries because 1) if left unspecified, the default is 10 and 2) 500 is the max.
+    /// </summary>
+    public class IGDBService : IIGDBService
+    {
+        private readonly IGDBSettings _settings;
+        private readonly IGDB.IGDBClient _client;
+        private readonly HttpClient _httpClient;
+
+        public IGDBService(ISecretsService secretsService)
+        {
+            _settings = secretsService.GetIGDBSettings();
+            _client = new(_settings.ClientId, _settings.ClientSecret);
+            _httpClient = new();
+        }
+
+        /// <summary>
+        /// Gets the time to beat of the specified game.
+        /// </summary>
+        /// <param name="game">The name of the game to get the time to beat of.</param>
+        /// <returns>Time to beat data.</returns>
+        public async Task<IGDBGameTimeToBeat> GetTimeToBeatAsync(string game)
+        {
+            var gameResults = await _client.QueryAsync<IGDB.Models.Game>(IGDBClient.Endpoints.Games, query: $"fields id,name; where name = \"{game}\" & version_parent = null;");
+            var target = gameResults.First();
+
+            var ttbResults = await _client.QueryAsync<IGDBGameTimeToBeat>("game_time_to_beats", query: $"fields *; where game_id = {target.Id};");
+            var ttb = ttbResults.FirstOrDefault() ?? new();
+            ttb.GameName = game;
+
+            return ttb;
+        }
+
+        /// <summary>
+        /// Gets the time to beat of all specified games.
+        /// </summary>
+        /// <param name="games">List of games to get times to beat of.</param>
+        /// <returns>Times to beat data.</returns>
+        public async Task<IEnumerable<IGDBGameTimeToBeat>> GetTimeToBeatAsync(IEnumerable<string> games)
+        {
+            // Clean up the game names. Remove symbols that might affect the results from IGDB.
+            games = games.Select(g =>
+            {
+                Regex r = new Regex("[:,™,®,\\.]");
+                string cleanName = r.Replace(g, String.Empty);
+                return $"\"{cleanName}\"";
+            });
+
+            // Generate where clause for the games query. We need this query because IGDB uses ids for other query types
+            // like "game_time_to_beat".
+            StringBuilder sb = new();
+            sb.Append("where name = (");
+            sb.Append(String.Join(',', games.ToArray()));
+            sb.Append(")");
+            string gamesWhereClause = sb.ToString();
+
+            var gameResults = await _client.QueryAsync<IGDB.Models.Game>(IGDBClient.Endpoints.Games, query: $"fields id,name; {gamesWhereClause}; limit 500;");
+
+            // Generate where clause for the ttb query.
+            sb.Clear();
+            sb.Append("where game_id = (");
+            sb.Append(String.Join(',', gameResults.Select(x => x.Id)));
+            sb.Append(")");
+            string ttbWhereClause = sb.ToString();
+
+            var ttbResults = await _client.QueryAsync<IGDBGameTimeToBeat>($"game_time_to_beats", query: $"fields *; {ttbWhereClause}; limit 500;");
+
+            // After we get the results, add the game's name to the associated ttb for more human readable results.
+            foreach ( var ttbResult in ttbResults )
+            {
+                ttbResult.GameName = gameResults.First(x => x.Id == ttbResult.GameId).Name;
+            }
+
+            return ttbResults;
+        }
+    }
+}

--- a/SteamWishlistTtBGraphQL/Services/IGDBService/IIGDBService.cs
+++ b/SteamWishlistTtBGraphQL/Services/IGDBService/IIGDBService.cs
@@ -1,0 +1,11 @@
+﻿using SteamWishlistTtBGraphQL.Models;
+using SteamWishlistTtBGraphQL.Models.Responses;
+
+namespace SteamWishlistTtBGraphQL.Services
+{
+    public interface IIGDBService
+    {
+        Task<IGDBGameTimeToBeat> GetTimeToBeatAsync(string game);
+        Task<IEnumerable<IGDBGameTimeToBeat>> GetTimeToBeatAsync(IEnumerable<string> games);
+    }
+}

--- a/SteamWishlistTtBGraphQL/Services/QueryService/IQueryService.cs
+++ b/SteamWishlistTtBGraphQL/Services/QueryService/IQueryService.cs
@@ -1,0 +1,13 @@
+﻿using SteamWishlistTtBGraphQL.GraphQL.Schema;
+using SteamWishlistTtBGraphQL.Models;
+using SteamWishlistTtBGraphQL.Models.Responses;
+
+namespace SteamWishlistTtBGraphQL.Services
+{
+    public interface IQueryService
+    {
+        Task<IEnumerable<MyGame>> GetGamesAsync(string userId);
+        Task<IGDBGameTimeToBeat> GetIGDBTimeToBeatAsync(string game);
+        Task<IEnumerable<IGDBGameTimeToBeat>> GetSteamGamesTTBAsync(string userId);
+    }
+}

--- a/SteamWishlistTtBGraphQL/Services/QueryService/QueryService.cs
+++ b/SteamWishlistTtBGraphQL/Services/QueryService/QueryService.cs
@@ -1,0 +1,46 @@
+﻿using SteamWishlistTtBGraphQL.GraphQL.Schema;
+using SteamWishlistTtBGraphQL.Models;
+using SteamWishlistTtBGraphQL.Models.Responses;
+
+namespace SteamWishlistTtBGraphQL.Services
+{
+    public class QueryService(
+        ISteamService steamService,
+        IIGDBService igdbService
+    ) : IQueryService
+    {
+        /// <summary>
+        /// Gets the Steam games of the specified user.
+        /// </summary>
+        /// <param name="userId">The Steam id of the user.</param>
+        /// <returns>List of Steam games of specified user.</returns>
+        public async Task<IEnumerable<MyGame>> GetGamesAsync(string userId)
+        {
+            var steamGames = await steamService.GetSteamGamesAsync(userId);
+            return steamGames.Select(sg => MyGame.FromSteamGame(sg));
+        }
+
+        /// <summary>
+        /// Gets the IGDB time to beat data of the specified game.
+        /// </summary>
+        /// <param name="game">The name of the game to get the time to beat of.</param>
+        /// <returns>IGDB time to beat data.</returns>
+        public async Task<IGDBGameTimeToBeat> GetIGDBTimeToBeatAsync(string game)
+        {
+            return await igdbService.GetTimeToBeatAsync(game);
+        }
+
+        /// <summary>
+        /// Gets the IGDB time to beat of all Steam games of the specified user.
+        /// </summary>
+        /// <param name="userId">The Steam id of the user.</param>
+        /// <returns>List of IGDB time to beat data of Steam games.</returns>
+        public async Task<IEnumerable<IGDBGameTimeToBeat>> GetSteamGamesTTBAsync(string userId)
+        {
+            var steamGames = await steamService.GetSteamGamesAsync(userId);
+            var ttb = await igdbService.GetTimeToBeatAsync(steamGames.Select(x => x.Name));
+
+            return ttb;
+        }
+    }
+}

--- a/SteamWishlistTtBGraphQL/Services/SecretsService/ISecretsService.cs
+++ b/SteamWishlistTtBGraphQL/Services/SecretsService/ISecretsService.cs
@@ -1,9 +1,10 @@
 ﻿using SteamWishlistTtBGraphQL.Models;
 
-namespace SteamWishlistTtBGraphQL.Services.SecretsService
+namespace SteamWishlistTtBGraphQL.Services
 {
     public interface ISecretsService
     {
         SteamSettings GetSteamSettings();
+        IGDBSettings GetIGDBSettings();
     }
 }

--- a/SteamWishlistTtBGraphQL/Services/SecretsService/ISecretsService.cs
+++ b/SteamWishlistTtBGraphQL/Services/SecretsService/ISecretsService.cs
@@ -1,0 +1,9 @@
+﻿using SteamWishlistTtBGraphQL.Models;
+
+namespace SteamWishlistTtBGraphQL.Services.SecretsService
+{
+    public interface ISecretsService
+    {
+        SteamSettings GetSteamSettings();
+    }
+}

--- a/SteamWishlistTtBGraphQL/Services/SecretsService/SecretsService.cs
+++ b/SteamWishlistTtBGraphQL/Services/SecretsService/SecretsService.cs
@@ -1,9 +1,19 @@
 ﻿using SteamWishlistTtBGraphQL.Models;
 
-namespace SteamWishlistTtBGraphQL.Services.SecretsService
+namespace SteamWishlistTtBGraphQL.Services
 {
     public class SecretsService(IConfiguration config) : ISecretsService
     {
+        /// <summary>
+        /// Gets the Steam settings from application config.
+        /// </summary>
+        /// <returns>The Steam settings.</returns>
         public SteamSettings GetSteamSettings() => config.GetSection("Steam").Get<SteamSettings>() ?? new();
+
+        /// <summary>
+        /// Gets the IGDB settings from the application config.
+        /// </summary>
+        /// <returns>The IGDB settings.</returns>
+        public IGDBSettings GetIGDBSettings() => config.GetSection("IGDB").Get<IGDBSettings>() ?? new();
     }
 }

--- a/SteamWishlistTtBGraphQL/Services/SecretsService/SecretsService.cs
+++ b/SteamWishlistTtBGraphQL/Services/SecretsService/SecretsService.cs
@@ -1,0 +1,9 @@
+﻿using SteamWishlistTtBGraphQL.Models;
+
+namespace SteamWishlistTtBGraphQL.Services.SecretsService
+{
+    public class SecretsService(IConfiguration config) : ISecretsService
+    {
+        public SteamSettings GetSteamSettings() => config.GetSection("Steam").Get<SteamSettings>() ?? new();
+    }
+}

--- a/SteamWishlistTtBGraphQL/Services/SteamService/ISteamService.cs
+++ b/SteamWishlistTtBGraphQL/Services/SteamService/ISteamService.cs
@@ -4,6 +4,6 @@ namespace SteamWishlistTtBGraphQL.Services
 {
     public interface ISteamService
     {
-        Task<List<SteamGameModel>> GetSteamGamesAsync(string userId);
+        Task<IEnumerable<SteamGameModel>> GetSteamGamesAsync(string userId);
     }
 }

--- a/SteamWishlistTtBGraphQL/Services/SteamService/SteamService.cs
+++ b/SteamWishlistTtBGraphQL/Services/SteamService/SteamService.cs
@@ -1,18 +1,25 @@
 ﻿using Newtonsoft.Json;
 using SteamWishlistTtBGraphQL.Models;
-using SteamWishlistTtBGraphQL.Responses.Steam;
-using SteamWishlistTtBGraphQL.Services.SecretsService;
+using SteamWishlistTtBGraphQL.Models.Responses;
 
 namespace SteamWishlistTtBGraphQL.Services
 {
     public class SteamService(ISecretsService secretsService) : ISteamService
     {
         private readonly HttpClient _httpClient = new();
+        private readonly static string BASE_STEAM_API_URI = "http://api.steampowered.com";
 
-        public async Task<List<SteamGameModel>> GetSteamGamesAsync(string userId)
+        /// <summary>
+        /// Gets the Steam games data of the specified user.
+        /// </summary>
+        /// <param name="userId">The Steam id of the user to get games data for.</param>
+        /// <returns>List of specified user's Steam game data.</returns>
+        public async Task<IEnumerable<SteamGameModel>> GetSteamGamesAsync(string userId)
         {
             var steamSettings = secretsService.GetSteamSettings();
-            var response = await _httpClient.GetAsync($"http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key={steamSettings.ApiKey}&steamid={userId}&include_appinfo=1&format=json");
+            var response = await _httpClient.GetAsync($"{BASE_STEAM_API_URI}/IPlayerService/GetOwnedGames/v0001/?key={steamSettings.ApiKey}&steamid={userId}&include_appinfo=1&format=json");
+            response.EnsureSuccessStatusCode();
+            
             var json = await response.Content.ReadAsStringAsync();
 
             var steamGameDataResponse = JsonConvert.DeserializeObject<Dictionary<string, SteamOwnedGamesResponse>>(json);

--- a/SteamWishlistTtBGraphQL/SteamWishlistTtBGraphQL.csproj
+++ b/SteamWishlistTtBGraphQL/SteamWishlistTtBGraphQL.csproj
@@ -10,7 +10,12 @@
   <ItemGroup>
     <PackageReference Include="HotChocolate.AspNetCore" Version="13.8.1" />
     <PackageReference Include="HotChocolate.Data" Version="13.8.1" />
+    <PackageReference Include="IGDB" Version="5.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Models\Requests\" />
   </ItemGroup>
 
 </Project>

--- a/SteamWishlistTtBGraphQL/SteamWishlistTtBGraphQL.csproj
+++ b/SteamWishlistTtBGraphQL/SteamWishlistTtBGraphQL.csproj
@@ -4,10 +4,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>944b8c79-3844-47e3-a17c-465af72f444c</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="HotChocolate.AspNetCore" Version="13.8.1" />
+    <PackageReference Include="HotChocolate.Data" Version="13.8.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
The endpoint uri I was using to get wishlisht game data no longer seems to be a thing? So, instead, just use the proper Steam API for Steam functionality. Also includes an endpoint for Steam library + IGDB time to beat data.